### PR TITLE
Fixed bug in Ldind instructions

### DIFF
--- a/CLRSharp/CLRSharp/Execute/CodeBody.cs
+++ b/CLRSharp/CLRSharp/Execute/CodeBody.cs
@@ -246,6 +246,14 @@ namespace CLRSharp
                 return method.Body;
             }
         }
+
+        public Mono.Collections.Generic.Collection<Mono.Cecil.ParameterDefinition> Parameters
+        {
+            get
+            {
+                return method.Parameters;
+            }
+        }
         bool bInited = false;
         public void Init(CLRSharp.ICLRSharp_Environment env)
         {

--- a/CLRSharp/CLRSharp/Execute/Context.cs
+++ b/CLRSharp/CLRSharp/Execute/Context.cs
@@ -87,13 +87,13 @@ namespace CLRSharp
                     str += "    ===Params(" + s._params.Length + ")===\n";
                     for (int i = 0; i < s._params.Length; i++)
                     {
-                        str += "        param" + i.ToString("D04") + s._params[i] + "\n";
+                        str += "        " + s.codebody.Parameters[i].Name + " = " + s._params[i] + "\n";
                     }
                 }
                 str += "    ===VarSlots(" + s.slotVar.Count + ")===\n";
                 for (int i = 0; i < s.slotVar.Count; i++)
                 {
-                    str += "        var" + i.ToString("D04") + s.slotVar[i] + "\n";
+                    str += "        var " + s.codebody.bodyNative.Variables[i].Name + " = " + s.slotVar[i] + "\n";
                 }
             }
             return str;

--- a/CLRSharp/CLRSharp/Execute/StackFrame.cs
+++ b/CLRSharp/CLRSharp/Execute/StackFrame.cs
@@ -2678,6 +2678,7 @@ namespace CLRSharp
                 //_pos = poss[pos];
             }
         }
+        
         public void Ldind_I1()
         {
             object obje = stackCalc.Pop();
@@ -2685,15 +2686,14 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));         
                 _codepos++;
                 return;
             }
             throw new Exception("not impl Ldind_I1:");
             //_codepos++;
         }
+
         public void Ldind_U1()
         {
             object obje = stackCalc.Pop();
@@ -2701,9 +2701,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2717,9 +2715,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2733,9 +2729,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2749,9 +2743,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2765,9 +2757,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2781,9 +2771,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2796,10 +2784,8 @@ namespace CLRSharp
             if (obje is RefObj)
             {
                 RefObj _ref = obje as RefObj;
-                object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                object value = _ref.Get(); 
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2813,9 +2799,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2829,9 +2813,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }

--- a/CLRSharp/CLRSharp/Execute/ValueOnStack.cs
+++ b/CLRSharp/CLRSharp/Execute/ValueOnStack.cs
@@ -305,6 +305,12 @@ namespace CLRSharp
             this.type = thistype;
             newcount++;
         }
+
+        public override string ToString()
+        {
+            var res = BoxDefine();
+            return res != null ? res.ToString() : "null";
+        }
         public VBox Clone()
         {
             VBox b = ValueOnStack.MakeVBox(this.type);


### PR DESCRIPTION
Test case:
void foo()
{
  int a = 0;
  bar(ref a);
}

void bar(ref int a)
{
 a++;
}

The ExecuteEngine will crash on LdInd_i4 instruction because of the wrong VBox
