### PR TITLE
Fixed bug in Ldind instructions 

### DIFF
--- a/CLRSharp/CLRSharp/Execute/CodeBody.cs
+++ b/CLRSharp/CLRSharp/Execute/CodeBody.cs
@@ -246,6 +246,14 @@ namespace CLRSharp
                 return method.Body;
             }
         }
+
+        public Mono.Collections.Generic.Collection<Mono.Cecil.ParameterDefinition> Parameters
+        {
+            get
+            {
+                return method.Parameters;
+            }
+        }
         bool bInited = false;
         public void Init(CLRSharp.ICLRSharp_Environment env)
         {

--- a/CLRSharp/CLRSharp/Execute/Context.cs
+++ b/CLRSharp/CLRSharp/Execute/Context.cs
@@ -87,13 +87,13 @@ namespace CLRSharp
                     str += "    ===Params(" + s._params.Length + ")===\n";
                     for (int i = 0; i < s._params.Length; i++)
                     {
-                        str += "        param" + i.ToString("D04") + s._params[i] + "\n";
+                        str += "        " + s.codebody.Parameters[i].Name + " = " + s._params[i] + "\n";
                     }
                 }
                 str += "    ===VarSlots(" + s.slotVar.Count + ")===\n";
                 for (int i = 0; i < s.slotVar.Count; i++)
                 {
-                    str += "        var" + i.ToString("D04") + s.slotVar[i] + "\n";
+                    str += "        var " + s.codebody.bodyNative.Variables[i].Name + " = " + s.slotVar[i] + "\n";
                 }
             }
             return str;

--- a/CLRSharp/CLRSharp/Execute/StackFrame.cs
+++ b/CLRSharp/CLRSharp/Execute/StackFrame.cs
@@ -1020,7 +1020,16 @@ namespace CLRSharp
             {
                 if (type == RefType.arg)
                 {
-                    frame._params[pos] = obj;
+                    var p = frame._params[pos];
+                    if (p is VBox)
+                    {
+                        if (obj is VBox)
+                            ((VBox)p).Set((VBox)obj);
+                        else
+                            ((VBox)p).SetDirect(obj);
+                    }
+                    else
+                        frame._params[pos] = obj;
                 }
                 else if (type == RefType.loc)
                 {
@@ -1028,7 +1037,16 @@ namespace CLRSharp
                     {
                         frame.slotVar.Add(null);
                     }
-                    frame.slotVar[pos] = obj;
+                    var loc = frame.slotVar[pos];
+                    if (loc is VBox)
+                    {
+                        if (obj is VBox)
+                            ((VBox)loc).Set((VBox)obj);
+                        else 
+                            ((VBox)loc).SetDirect(obj);
+                    }
+                    else
+                        frame.slotVar[pos] = obj;
                 }
                 else if (type == RefType.field)
                 {

--- a/CLRSharp/CLRSharp/Execute/StackFrame.cs
+++ b/CLRSharp/CLRSharp/Execute/StackFrame.cs
@@ -208,12 +208,19 @@ namespace CLRSharp
         }
         public object Return()
         {
-
+            if (_params != null)
+            {
+                foreach (var i in _params)
+                {
+                    VBox box = i as VBox;
+                    if (box != null)
+                        ValueOnStack.UnUse(box);
+                }
+            }
             this.slotVar.ClearVBox();
             if (this.stackCalc.Count == 0) return null;
             object ret = stackCalc.Pop();
             this.stackCalc.ClearVBox();
-
             return ret;
         }
         void FillArray(object array, byte[] bytes)

--- a/CLRSharp/CLRSharp/Execute/StackFrame.cs
+++ b/CLRSharp/CLRSharp/Execute/StackFrame.cs
@@ -1242,15 +1242,22 @@ namespace CLRSharp
             }
             return box;
         }
-
-
-
-
-
-
-
-
-
+        
+        public VBox GetVBoxCloned(object obj)
+        {
+            VBox box = null;
+            if (obj is VBox)
+            {
+                box = obj as VBox;
+                box = box.Clone();
+            }
+            else
+            {
+                box = ValueOnStack.MakeVBox(obj.GetType());
+                box.SetDirect(obj);
+            }
+            return box;
+        }
 
         public void Sub()
         {
@@ -2686,7 +2693,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                stackCalc.Push(GetVBox(value));         
+                stackCalc.Push(GetVBoxCloned(value));         
                 _codepos++;
                 return;
             }
@@ -2701,7 +2708,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                stackCalc.Push(GetVBox(value));
+                stackCalc.Push(GetVBoxCloned(value));
                 _codepos++;
                 return;
             }
@@ -2715,7 +2722,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                stackCalc.Push(GetVBox(value));
+                stackCalc.Push(GetVBoxCloned(value));
                 _codepos++;
                 return;
             }
@@ -2729,7 +2736,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                stackCalc.Push(GetVBox(value));
+                stackCalc.Push(GetVBoxCloned(value));
                 _codepos++;
                 return;
             }
@@ -2743,7 +2750,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                stackCalc.Push(GetVBox(value));
+                stackCalc.Push(GetVBoxCloned(value));
                 _codepos++;
                 return;
             }
@@ -2757,7 +2764,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                stackCalc.Push(GetVBox(value));
+                stackCalc.Push(GetVBoxCloned(value));
                 _codepos++;
                 return;
             }
@@ -2771,7 +2778,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                stackCalc.Push(GetVBox(value));
+                stackCalc.Push(GetVBoxCloned(value));
                 _codepos++;
                 return;
             }
@@ -2784,8 +2791,8 @@ namespace CLRSharp
             if (obje is RefObj)
             {
                 RefObj _ref = obje as RefObj;
-                object value = _ref.Get(); 
-                stackCalc.Push(GetVBox(value));
+                object value = _ref.Get();
+                stackCalc.Push(GetVBoxCloned(value));
                 _codepos++;
                 return;
             }
@@ -2799,7 +2806,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                stackCalc.Push(GetVBox(value));
+                stackCalc.Push(GetVBoxCloned(value));
                 _codepos++;
                 return;
             }
@@ -2813,7 +2820,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                stackCalc.Push(GetVBox(value));
+                stackCalc.Push(GetVBoxCloned(value));
                 _codepos++;
                 return;
             }

--- a/CLRSharp/CLRSharp/Execute/StackFrame.cs
+++ b/CLRSharp/CLRSharp/Execute/StackFrame.cs
@@ -2678,6 +2678,7 @@ namespace CLRSharp
                 //_pos = poss[pos];
             }
         }
+        
         public void Ldind_I1()
         {
             object obje = stackCalc.Pop();
@@ -2685,15 +2686,14 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));         
                 _codepos++;
                 return;
             }
             throw new Exception("not impl Ldind_I1:");
             //_codepos++;
         }
+
         public void Ldind_U1()
         {
             object obje = stackCalc.Pop();
@@ -2701,9 +2701,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2717,9 +2715,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2733,9 +2729,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2749,9 +2743,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2765,9 +2757,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2781,9 +2771,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2796,10 +2784,8 @@ namespace CLRSharp
             if (obje is RefObj)
             {
                 RefObj _ref = obje as RefObj;
-                object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                object value = _ref.Get(); 
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2813,9 +2799,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }
@@ -2829,9 +2813,7 @@ namespace CLRSharp
             {
                 RefObj _ref = obje as RefObj;
                 object value = _ref.Get();
-                VBox box = ValueOnStack.MakeVBox(value.GetType());
-                box.SetDirect(value);
-                stackCalc.Push(box);
+                stackCalc.Push(GetVBox(value));
                 _codepos++;
                 return;
             }

--- a/CLRSharp/CLRSharp/Execute/ValueOnStack.cs
+++ b/CLRSharp/CLRSharp/Execute/ValueOnStack.cs
@@ -305,6 +305,12 @@ namespace CLRSharp
             this.type = thistype;
             newcount++;
         }
+
+        public override string ToString()
+        {
+            var res = BoxDefine();
+            return res != null ? res.ToString() : "null";
+        }
         public VBox Clone()
         {
             VBox b = ValueOnStack.MakeVBox(this.type);

--- a/UnitTestDll/Test_Byliiir1985.cs
+++ b/UnitTestDll/Test_Byliiir1985.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnitTest;
+using System.Collections;
+
+namespace UnitTestDll
+{
+    class Test_Byliiir1985
+    {
+        /// <summary>
+        /// 性能测试
+        /// </summary>
+        /// <returns></returns>
+        public static void UnitTest_Performance()
+        {
+            System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
+            sw.Start();
+            int cnt = 0;
+            for (int i = 0; i < 100000; i++)
+            {
+                cnt += i;
+            }
+            sw.Stop();
+
+            Logger.Log(string.Format("Elapsed time:{0:0}ms, result = {1}", sw.ElapsedMilliseconds, cnt));
+
+            sw.Reset();
+            sw.Start();
+            cnt = 0;
+            for (int i = 0; i < 100000; i++)
+            {
+                FuncCallResult(ref cnt, i);
+            }
+            sw.Stop();
+
+            Logger.Log(string.Format("Elapsed time:{0:0}ms, result = {1}", sw.ElapsedMilliseconds, cnt));
+        }
+
+        public static void UnitTest_Cls()
+        {
+            Test1098Cls cls = new Test1098Cls();
+            Test1098Sub(cls);
+
+            Logger.Log(string.Format("A={0} B={1}", cls.A, cls.B));
+        }
+
+        public static void UnitTest_Generics()
+        {
+            //如果一个类继承一个泛型参数为这个类本身的泛型类，就没法正确找到该类型了
+            Logger.Log(SingletonTest.Inst.foo());
+        }
+
+        public static void UnitTest_NestedGenerics()
+        {
+            //如果一个嵌套的类是泛型类参数，则这个类无法被找到
+            Logger.Log(new NestedTestBase<NestedTest>().ToString());
+        }
+
+        class Test1098Cls
+        {
+            public int A { get; set; }
+            public string B { get; set; }
+        }
+
+        static void Test1098Sub(Test1098Cls cls)
+        {
+            cls.A = 2;
+            cls.B = "ok";
+        }
+
+        static void FuncCallResult(ref int cnt, int i)
+        {
+            cnt++;
+        }
+
+        class NestedTest
+        {
+
+        }
+
+        class NestedTestBase<T>
+        {
+
+        }
+    }
+
+    class SingletonTest : Singleton<SingletonTest>
+    {
+        public string foo()
+        {
+            return "bar";
+        }
+    }
+    class Singleton<T> where T : new()
+    {
+        private static T _inst;
+
+        protected Singleton()
+        {
+        }
+
+        public static T Inst
+        {
+            get
+            {
+                if (Singleton<T>._inst == null)
+                {
+                    Singleton<T>._inst = (default(T) == null) ? Activator.CreateInstance<T>() : default(T);
+                }
+                return Singleton<T>._inst;
+            }
+        }
+    }
+}

--- a/UnitTestDll/UnitTestDll.csproj
+++ b/UnitTestDll/UnitTestDll.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Test0.cs" />
     <Compile Include="LightTestor\ExpTest_10.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Test_Byliiir1985.cs" />
     <Compile Include="Test_ByLynn.cs" />
     <Compile Include="Test_ByDuskforest.cs" />
     <Compile Include="test_enum.cs" />


### PR DESCRIPTION
Test case:
 void foo()
 {
 int a = 0;
 bar(ref a);
 }

void bar(ref int a)
 {
 a++;
 }

The ExecuteEngine will crash on LdInd_i4 instruction because of the wrong VBox
